### PR TITLE
Verrouillage mono-commune

### DIFF
--- a/lib/routes/__tests__/base-locale.js
+++ b/lib/routes/__tests__/base-locale.js
@@ -406,7 +406,7 @@ test.serial('add a second commune to a BaseLocale / with admin token', async t =
     _updated: new Date('2019-01-01')
   })
 
-  const {body, status} = await request(getApp())
+  const {status} = await request(getApp())
     .put(`/bases-locales/${_id}/communes/27115`)
     .set({Authorization: 'Token coucou'})
 

--- a/lib/routes/__tests__/base-locale.js
+++ b/lib/routes/__tests__/base-locale.js
@@ -394,6 +394,25 @@ test.serial('add a commune to a BaseLocal / with admin token', async t => {
   t.is(body.communes[0], '27115')
 })
 
+test.serial('add a second commune to a BaseLocale / with admin token', async t => {
+  const _id = new mongo.ObjectId()
+  await mongo.db.collection('bases_locales').insertOne({
+    _id,
+    nom: 'foo',
+    emails: ['me@domain.co'],
+    communes: ['12345'],
+    token: 'coucou',
+    _created: new Date('2019-01-01'),
+    _updated: new Date('2019-01-01')
+  })
+
+  const {body, status} = await request(getApp())
+    .put(`/bases-locales/${_id}/communes/27115`)
+    .set({Authorization: 'Token coucou'})
+
+  t.is(status, 403)
+})
+
 test.serial('add a commune to a BaseLocal / invalid commune', async t => {
   const _id = new mongo.ObjectId()
   await mongo.db.collection('bases_locales').insertOne({
@@ -431,7 +450,27 @@ test.serial('add a commune to a BaseLocal / without admin token', async t => {
   t.is(status, 403)
 })
 
-test.serial('remove a commune from a BaseLocal / with admin token', async t => {
+test.serial('remove a commune from a BaseLocale / with admin token', async t => {
+  const _id = new mongo.ObjectId()
+  await mongo.db.collection('bases_locales').insertOne({
+    _id,
+    nom: 'foo',
+    emails: ['me@domain.co'],
+    communes: ['12345', '27115'],
+    token: 'coucou',
+    _created: new Date('2019-01-01'),
+    _updated: new Date('2019-01-01')
+  })
+
+  const {body, status} = await request(getApp())
+    .delete(`/bases-locales/${_id}/communes/27115`)
+    .set({Authorization: 'Token coucou'})
+
+  t.is(status, 200)
+  t.deepEqual(body.communes, ['12345'])
+})
+
+test.serial('remove the last commune from a BaseLocale / with admin token', async t => {
   const _id = new mongo.ObjectId()
   await mongo.db.collection('bases_locales').insertOne({
     _id,
@@ -443,12 +482,11 @@ test.serial('remove a commune from a BaseLocal / with admin token', async t => {
     _updated: new Date('2019-01-01')
   })
 
-  const {body, status} = await request(getApp())
+  const {status} = await request(getApp())
     .delete(`/bases-locales/${_id}/communes/27115`)
     .set({Authorization: 'Token coucou'})
 
-  t.is(status, 200)
-  t.deepEqual(body.communes, [])
+  t.is(status, 403)
 })
 
 test.serial('remove a commune from a BaseLocal / invalid commune', async t => {
@@ -457,7 +495,7 @@ test.serial('remove a commune from a BaseLocal / invalid commune', async t => {
     _id,
     nom: 'foo',
     emails: ['me@domain.co'],
-    communes: ['27115'],
+    communes: ['55555', '27115'],
     token: 'coucou',
     _created: new Date('2019-01-01'),
     _updated: new Date('2019-01-01')

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -1,5 +1,6 @@
 const express = require('express')
 const bodyParser = require('body-parser')
+const createError = require('http-errors')
 const w = require('../util/w')
 const BaseLocale = require('../models/base-locale')
 const Voie = require('../models/voie')
@@ -179,10 +180,18 @@ app.route('/bases-locales/:baseLocaleId/communes/:codeCommune')
     res.send(commune)
   }))
   .put(ensureIsAdmin, w(async (req, res) => {
+    if (req.baseLocale.communes.length > 0) {
+      throw createError(403, 'Cette BAL est déjà rattachée à une commune')
+    }
+
     const baseLocale = await BaseLocale.addCommune(req.baseLocale._id, req.params.codeCommune)
     res.send(baseLocale)
   }))
   .delete(ensureIsAdmin, w(async (req, res) => {
+    if (req.baseLocale.communes.length === 1) {
+      throw createError(403, 'Une BAL doit être rattachée à au moins une commune')
+    }
+
     const baseLocale = await BaseLocale.removeCommune(req.baseLocale._id, req.params.codeCommune)
     res.send(baseLocale)
   }))


### PR DESCRIPTION
Restreint les appels permettant d'ajouter et supprimer une commune d'une BAL pour :
- interdire la suppression de la dernière commune d'une BAL
- interdire l'ajout d'une nouvelle commune à une BAL qui en a déjà une

Mes-Adresses est déjà conforme à ces changements.