### PR TITLE
Ajout du nombre de numéros certifiés dans les statistiques

### DIFF
--- a/lib/models/base-locale.js
+++ b/lib/models/base-locale.js
@@ -456,6 +456,22 @@ async function updateHabilitation(baseLocaleId, habilitationId) {
   )
 }
 
+async function expandModel(basesLocales) {
+  const expandedBasesLocales = []
+
+  await Promise.all(basesLocales.map(async b => {
+    let nbNumerosCertifies = 0
+    await Promise.all(b.communes.map(async c => {
+      const commune = await getCommune(b._id, c)
+      nbNumerosCertifies += commune.nbNumerosCertifies
+    }))
+
+    expandedBasesLocales.push({...b, nbNumerosCertifies})
+  }))
+
+  return expandedBasesLocales
+}
+
 module.exports = {
   create,
   createSchema,
@@ -485,5 +501,6 @@ module.exports = {
   getAssignedParcelles,
   getCommune,
   batchUpdateNumeros,
-  updateHabilitation
+  updateHabilitation,
+  expandModel
 }

--- a/lib/models/numero.js
+++ b/lib/models/numero.js
@@ -204,6 +204,10 @@ async function fetchAll(idVoie) {
   return mongo.db.collection('numeros').find({voie: idVoie}).sort({numero: 1}).toArray()
 }
 
+async function countNumerosCertifies() {
+  return mongo.db.collection('numeros').find({certifie: true}).count()
+}
+
 async function fetchByToponyme(id) {
   const numerosWithToponyme = await mongo.db.collection('numeros').find({toponyme: id}).toArray()
   const voiesIds = uniqBy(numerosWithToponyme.map(n => n.voie), voieId => voieId.toString())
@@ -302,6 +306,7 @@ module.exports = {
   updateSchema,
   fetchOne,
   fetchAll,
+  countNumerosCertifies,
   fetchByToponyme,
   remove,
   expandModel,

--- a/lib/routes/__tests__/stats.js
+++ b/lib/routes/__tests__/stats.js
@@ -12,7 +12,7 @@ function getApp() {
   return app
 }
 
-const SAFE_FIELDS = ['nom', '_updated', '_created', '_id', 'communes']
+const SAFE_FIELDS = ['nom', '_updated', '_created', '_id', 'communes', 'nbNumerosCertifies']
 
 let mongod
 

--- a/lib/routes/stats.js
+++ b/lib/routes/stats.js
@@ -28,8 +28,9 @@ app.route('/departements/:codeDepartement')
     }
 
     const basesLocales = await BaseLocale.fetchByCommunes(codesCommunes)
+    const expandedBasesLocales = await BaseLocale.expandModel(basesLocales)
 
-    res.send(basesLocales.map(bal => BaseLocale.filterSensitiveFields(bal)))
+    res.send(expandedBasesLocales.map(bal => BaseLocale.filterSensitiveFields(bal)))
   }))
 
 module.exports = app

--- a/lib/routes/stats.js
+++ b/lib/routes/stats.js
@@ -2,9 +2,15 @@ const express = require('express')
 const departements = require('@etalab/decoupage-administratif/data/departements.json')
 const w = require('../util/w')
 const BaseLocale = require('../models/base-locale')
+const Numero = require('../models/numero')
 const {getCommunesByDepartement} = require('../util/cog')
 
 const app = new express.Router()
+
+app.route('/numeros-certifies')
+  .get(w(async (req, res) => {
+    res.send({nbNumerosCertifies: await Numero.countNumerosCertifies()})
+  }))
 
 app.route('/couverture-bal')
   .get(w(async (req, res) => {


### PR DESCRIPTION
- Ajout d'une nouvelle route : `/stats/numeros-certifies`
retourne : 
```js
{
 nbNumerosCertifies: (int)
}
```

- Ajout de la méthode `expandModel` à `BaseLocale`
ajoute la propriété `nbNumerosCertifies`

Liée à la PR [mes-adresses #479](https://github.com/BaseAdresseNationale/mes-adresses/pull/479)
