### PR TITLE
Limitation à une commune lors du téléversement d'un fichier csv

### DIFF
--- a/lib/models/base-locale.js
+++ b/lib/models/base-locale.js
@@ -292,8 +292,7 @@ async function streamToGeoJSON(id, codeCommune) {
   return transformToGeoJSON({voiesCursor, numerosCursor, toponymesCursor})
 }
 
-async function importFile(id, file) {
-  const {voies, numeros, toponymes, isValid, accepted, rejected} = await extractFromCsv(file)
+async function importFile(id, file, codeCommune) {
 
   if (!isValid) {
     return {isValid: false}

--- a/lib/models/base-locale.js
+++ b/lib/models/base-locale.js
@@ -293,6 +293,7 @@ async function streamToGeoJSON(id, codeCommune) {
 }
 
 async function importFile(id, file, codeCommune) {
+  const {voies, numeros, toponymes, isValid, accepted, rejected} = await extractFromCsv(file, codeCommune)
 
   if (!isValid) {
     return {isValid: false}

--- a/lib/populate/__tests__/extract-csv.js
+++ b/lib/populate/__tests__/extract-csv.js
@@ -19,7 +19,7 @@ const csvFile = `cle_interop;uid_adresse;voie_nom;lieudit_complement_nom;numero;
 55326_xxxx_99999;;Toponyme Vide;;99999;;Maulan;segment;5.247276;48.664948;865475.13;6842886.26;;;2021-04-27`
 
 test('import CSV file', async t => {
-  const {isValid, accepted, numeros, voies, toponymes} = await extractFromCsv(Buffer.from(csvFile))
+  const {isValid, accepted, numeros, voies, toponymes} = await extractFromCsv(Buffer.from(csvFile), '55326')
 
   t.true(isValid)
   t.is(accepted, 15)

--- a/lib/populate/extract-csv.js
+++ b/lib/populate/extract-csv.js
@@ -1,5 +1,5 @@
 const {validate} = require('@etalab/bal')
-const {flatten, chain, compact, deburr, keyBy, min, max} = require('lodash')
+const {chain, compact, deburr, keyBy, min, max} = require('lodash')
 const {ObjectId} = require('../util/mongo')
 
 function normalizeString(string) {
@@ -118,18 +118,15 @@ async function extractFromCsv(file, codeCommune) {
     const parsedValues = accepted.map(({parsedValues}) => parsedValues)
       .filter(p => p.cle_interop.slice(0, 5) === codeCommune)
 
-    const communesData = chain(parsedValues)
-      .groupBy(row => row.cle_interop.slice(0, 5))
-      .map(communeRows => extractData(communeRows, codeCommune))
-      .value()
+    const communesData = extractData(parsedValues, codeCommune)
 
     return {
       isValid: true,
       accepted: accepted.length,
       rejected: rejected.length,
-      voies: flatten(communesData.map(d => d.voies)),
-      numeros: flatten(communesData.map(d => d.numeros)),
-      toponymes: flatten(communesData.map(d => d.toponymes))
+      voies: communesData.voies,
+      numeros: communesData.numeros,
+      toponymes: communesData.toponymes
     }
   } catch (error) {
     return {isValid: false, validationError: error.message}

--- a/lib/populate/extract-csv.js
+++ b/lib/populate/extract-csv.js
@@ -24,7 +24,7 @@ function extractDate(row) {
   }
 }
 
-function extractData(rows, {codeCommune}) {
+function extractData(rows, codeCommune) {
   const toponymes = chain(rows)
     .filter(r => r.numero === 99999)
     .groupBy(r => normalizeString(r.voie_nom))
@@ -105,7 +105,7 @@ function extractData(rows, {codeCommune}) {
   return {voies, numeros, toponymes}
 }
 
-async function extractFromCsv(file) {
+async function extractFromCsv(file, codeCommune) {
   try {
     const {rows, parseOk} = await validate(file)
 
@@ -116,21 +116,20 @@ async function extractFromCsv(file) {
     const accepted = rows.filter(({isValid}) => isValid)
     const rejected = rows.filter(({isValid}) => !isValid)
     const parsedValues = accepted.map(({parsedValues}) => parsedValues)
+      .filter(p => p.cle_interop.slice(0, 5) === codeCommune)
 
     const communesData = chain(parsedValues)
       .groupBy(row => row.cle_interop.slice(0, 5))
-      .mapValues((communeRows, codeCommune) => {
-        return extractData(communeRows, {codeCommune})
-      })
+      .map(communeRows => extractData(communeRows, codeCommune))
       .value()
 
     return {
       isValid: true,
       accepted: accepted.length,
       rejected: rejected.length,
-      voies: flatten(Object.values(communesData).map(d => d.voies)),
-      numeros: flatten(Object.values(communesData).map(d => d.numeros)),
-      toponymes: flatten(Object.values(communesData).map(d => d.toponymes))
+      voies: flatten(communesData.map(d => d.voies)),
+      numeros: flatten(communesData.map(d => d.numeros)),
+      toponymes: flatten(communesData.map(d => d.toponymes))
     }
   } catch (error) {
     return {isValid: false, validationError: error.message}

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -147,7 +147,7 @@ app.route('/bases-locales/:baseLocaleId/communes/:codeCommune/upload')
       return res.status(400).send({code: 400, message: 'CSV file required'})
     }
 
-    const result = await BaseLocale.importFile(req.baseLocale._id, req.body)
+    const result = await BaseLocale.importFile(req.baseLocale._id, req.body, req.params.codeCommune)
     res.send(result)
   }))
 

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -141,7 +141,7 @@ app.route('/bases-locales/:baseLocaleId/transform-to-draft')
     res.send(baseLocale)
   }))
 
-app.route('/bases-locales/:baseLocaleId/upload')
+app.route('/bases-locales/:baseLocaleId/communes/:codeCommune/upload')
   .post(ensureIsAdmin, bodyParser.raw({limit: '50mb', type: 'text/csv'}), w(async (req, res) => {
     if (!Buffer.isBuffer(req.body)) {
       return res.status(400).send({code: 400, message: 'CSV file required'})


### PR DESCRIPTION
Avec cette PR, la création de BAL contenant plusieurs communes ne sera plus possible lors du téléversement d'un fichier csv

- La route `/bases-locales/:baseLocaleId/upload` devient `/bases-locales/:baseLocaleId/communes/:codeCommune/upload`
- Ajout de l'argument `codeCommune` à la méthode `BaseLocale.importFile`
- Modification de la méthode `extractFromCsv` afin qu'elle ne prenne en compte qu'une commune
- Mise à jour du test `extract-bal`

## Liée à la PR [mes-adresse #480](https://github.com/BaseAdresseNationale/mes-adresses/pull/480)