### PR TITLE
Suppression de règles de filtration obsolètes à l'import BAN

### DIFF
--- a/lib/models/__tests__/base-locale.mongo.js
+++ b/lib/models/__tests__/base-locale.mongo.js
@@ -307,11 +307,11 @@ test('populate a commune', async t => {
 
   const voie = await mongo.db.collection('voies').findOne({_bal: _id, commune: '54084', nom: 'allée des acacias'})
   t.truthy(voie)
-  t.is(await mongo.db.collection('numeros').countDocuments({_bal: _id, voie: voie._id, commune: '54084'}), 49)
-  t.is(await mongo.db.collection('voies').countDocuments({_bal: _id, commune: '54084'}), 20)
-  t.is(await mongo.db.collection('numeros').countDocuments({_bal: _id, commune: '54084'}), 445)
+  t.is(await mongo.db.collection('numeros').countDocuments({_bal: _id, voie: voie._id, commune: '54084'}), 57)
+  t.is(await mongo.db.collection('voies').countDocuments({_bal: _id, commune: '54084'}), 22)
+  t.is(await mongo.db.collection('numeros').countDocuments({_bal: _id, commune: '54084'}), 490)
   const distinctVoies = await mongo.db.collection('numeros').distinct('voie', {_bal: _id, commune: '54084'})
-  t.is(distinctVoies.length, 20)
+  t.is(distinctVoies.length, 22)
 })
 
 test('find Bases Locales by codes communes', async t => {

--- a/lib/populate/__tests__/extract-ban.js
+++ b/lib/populate/__tests__/extract-ban.js
@@ -7,7 +7,7 @@ test('extract a single commune / 54084', async t => {
   mockBan54084()
 
   const {voies, numeros} = await extractFromBAN('54084')
-  t.is(voies.length, 20)
-  t.is(numeros.length, 445)
-  t.is(uniqBy(numeros, n => n.voie.toHexString()).length, 20)
+  t.is(voies.length, 22)
+  t.is(numeros.length, 490)
+  t.is(uniqBy(numeros, n => n.voie.toHexString()).length, 22)
 })

--- a/lib/populate/extract-ban.js
+++ b/lib/populate/extract-ban.js
@@ -20,10 +20,6 @@ async function extractFromBAN(codeCommune) {
       const suffixe = a.rep.toLowerCase() || null
       const nomVoie = a.nom_voie
 
-      if (!nomVoie || !Number.isInteger(numero) || numero === 0 || numero > 5000) {
-        return null
-      }
-
       const adresse = {
         codeCommune,
         nomVoie,

--- a/lib/routes/__tests__/base-locale.js
+++ b/lib/routes/__tests__/base-locale.js
@@ -540,7 +540,7 @@ test('export as CSV', async t => {
   t.is(status, 200)
   t.is(headers['content-disposition'], 'attachment; filename="bal.csv"')
   t.is(headers['content-type'], 'text/csv; charset=utf-8')
-  t.is(text.split('\r\n').length, 447)
+  t.is(text.split('\r\n').length, 492)
 })
 
 test('Export as GeoJSON', async t => {
@@ -555,7 +555,7 @@ test('Export as GeoJSON', async t => {
   t.is(status, 200)
   t.is(headers['content-type'], 'application/json; charset=utf-8')
   t.is(body.type, 'FeatureCollection')
-  t.is(body.features.length, 445)
+  t.is(body.features.length, 490)
 })
 
 test.serial('renew token / with admin token', async t => {


### PR DESCRIPTION
Règles supprimées :
- lorsque le nom de la voie n'est pas présent (impossible)
- lorsque le numéro est invalide ou 0 ou >5000 (impossible ou plus problématique à ce jour de par le fonctionnement de la BAN)